### PR TITLE
`return` statement

### DIFF
--- a/examples/syntax/04_code_block.func
+++ b/examples/syntax/04_code_block.func
@@ -2,10 +2,16 @@
 let result = {
     let a = 1
     let b = 2
-    return a + b
+    return a + b // You can remove the return keyword if the expression is the last one in the block.
 }
 
-write("result is: ", result , "\n") // result is: 3
+let result2 = {
+    let a = 1
+    let b = 2
+    a + b // This will return the value of the last expression in the block.
+}
+
+write("result is: ", result + result2, "\n") // result is: 6
 
 {
     let god = "nature"              // Well, I'm an Spinozist : )

--- a/examples/syntax/04_code_block.func
+++ b/examples/syntax/04_code_block.func
@@ -1,6 +1,15 @@
-{
-    let god = "nature"                              // Well, I'm an Spinozist : )
-    write("god is: " + god + ".\n")         // String concatination
+// Return a value from a block, using the return keyword.
+let result = {
+    let a = 1
+    let b = 2
+    return a + b
 }
 
-write(god)          // This will thorw an RuntimeError because god has gone out of scope.
+write("result is: ", result , "\n") // result is: 3
+
+{
+    let god = "nature"              // Well, I'm an Spinozist : )
+    write("god is: " + god + ".\n") // String concatination
+}
+
+write(god) // This will thorw an RuntimeError because god has gone out of scope.

--- a/examples/syntax/05_conditional.func
+++ b/examples/syntax/05_conditional.func
@@ -1,9 +1,11 @@
-let everyting = "cosmos"
+let everyting = "cosmoas"
 
-if everyting == nil {
-    write("I don't agree with you.\n")
+let message = if everyting == nil {
+    return "I don't agree with you.\n"
 } else if everyting == "cosmos" {
-    write("I also think the same.\n")
+    return "I also think the same.\n"
 } else {
-    write("I dunno!\n")
+    return "I dunno!\n"
 }
+
+write(message, "\n")

--- a/examples/syntax/05_conditional.func
+++ b/examples/syntax/05_conditional.func
@@ -8,4 +8,16 @@ let message = if everyting == nil {
     return "I dunno!\n"
 }
 
-write(message, "\n")
+write(message)
+
+// You can also remove the return keyword and it's will return the last expression in the block.
+
+let message = if everyting == nil {
+    "I don't agree with you.\n"
+} else if everyting == "cosmos" {
+    "I also think the same.\n"
+} else {
+    "I dunno!\n"
+}
+
+write(message)

--- a/examples/syntax/06_function.func
+++ b/examples/syntax/06_function.func
@@ -7,3 +7,26 @@ func say_my_name(name) {
 }
 
 say_my_name("heisenberg") // you are... heisenberg
+
+func add2(x) {
+    // There is no return statement, so the last expression is returned
+    if x == 0 {
+        2
+    } else {
+        1 + add2(x - 1)
+    }
+}
+
+write(add2(5)) // 7
+
+func add3(x) {
+    // The return statement have been used in the if statement, 
+    // so the if statement will return a return statement. then the function will return the return statement directly.
+    if x <= 0 {
+        return 3
+    } else {
+        2 + add2(x - 1)
+    }
+}
+
+write(add3(-5)) // 3

--- a/examples/syntax/06_function.func
+++ b/examples/syntax/06_function.func
@@ -1,5 +1,9 @@
-func say_my_name(name) {
-    write("you are... ", name, "\n")
+func say_name_message(name) {
+    return "you are... " + name + "\n"
 }
 
-say_my_name("heisenberg")
+func say_my_name(name) {
+    write(say_name_message(name))
+}
+
+say_my_name("heisenberg") // you are... heisenberg

--- a/src/common/ast.rs
+++ b/src/common/ast.rs
@@ -6,10 +6,10 @@ pub type Program = Vec<Statement>;
 pub enum Statement {
     Let(LetStatement),
     Assignment(AssignmentStatement),
-    Block(BlockStatement),
     If(IfStatement),
     Function(FunctionStatement),
     BuiltinFunction(BuiltinFunctionStatement),
+    Return(Expression),
     Expression(Expression),
 }
 
@@ -23,7 +23,7 @@ pub enum BuiltinFunction {
 
 #[derive(Debug, Clone)]
 pub enum ElseBlock {
-    Block(BlockStatement),
+    Block(BlockExpression),
     If(IfStatement),
 }
 
@@ -58,11 +58,11 @@ impl AssignmentStatement {
 }
 
 #[derive(Debug, Clone)]
-pub struct BlockStatement {
+pub struct BlockExpression {
     pub statements: Box<Vec<Statement>>,
 }
 
-impl BlockStatement {
+impl BlockExpression {
     pub fn new(statements: Vec<Statement>) -> Self {
         Self {
             statements: Box::new(statements),
@@ -73,14 +73,14 @@ impl BlockStatement {
 #[derive(Debug, Clone)]
 pub struct IfStatement {
     pub condition: Expression,
-    pub if_block: BlockStatement,
+    pub if_block: BlockExpression,
     pub else_block: Box<Option<ElseBlock>>,
 }
 
 impl IfStatement {
     pub fn new(
         condition: Expression,
-        if_block: BlockStatement,
+        if_block: BlockExpression,
         else_block: Option<ElseBlock>,
     ) -> Self {
         Self {
@@ -95,7 +95,7 @@ impl IfStatement {
 pub struct FunctionStatement {
     pub identifier: Token,
     pub paramiters: Vec<Token>,
-    pub block: BlockStatement,
+    pub block: BlockExpression,
     pub is_builtin: bool,
 }
 
@@ -103,7 +103,7 @@ impl FunctionStatement {
     pub fn new(
         identifier: Token,
         paramiters: Vec<Token>,
-        block: BlockStatement,
+        block: BlockExpression,
         is_builtin: bool,
     ) -> Self {
         Self {
@@ -132,6 +132,7 @@ impl BuiltinFunctionStatement {
 
 #[derive(Debug, Clone)]
 pub enum Expression {
+    Block(BlockExpression),
     Binary(BinaryExpression),
     Unary(UnaryExpression),
     Group(GroupExpression),

--- a/src/common/ast.rs
+++ b/src/common/ast.rs
@@ -6,7 +6,6 @@ pub type Program = Vec<Statement>;
 pub enum Statement {
     Let(LetStatement),
     Assignment(AssignmentStatement),
-    If(IfStatement),
     Function(FunctionStatement),
     BuiltinFunction(BuiltinFunctionStatement),
     Return(Expression),
@@ -24,7 +23,7 @@ pub enum BuiltinFunction {
 #[derive(Debug, Clone)]
 pub enum ElseBlock {
     Block(BlockExpression),
-    If(IfStatement),
+    If(IfExpression),
 }
 
 #[derive(Debug, Clone)]
@@ -71,20 +70,20 @@ impl BlockExpression {
 }
 
 #[derive(Debug, Clone)]
-pub struct IfStatement {
-    pub condition: Expression,
+pub struct IfExpression {
+    pub condition: Box<Expression>,
     pub if_block: BlockExpression,
     pub else_block: Box<Option<ElseBlock>>,
 }
 
-impl IfStatement {
+impl IfExpression {
     pub fn new(
         condition: Expression,
         if_block: BlockExpression,
         else_block: Option<ElseBlock>,
     ) -> Self {
         Self {
-            condition,
+            condition: Box::new(condition),
             if_block,
             else_block: Box::new(else_block),
         }
@@ -133,6 +132,7 @@ impl BuiltinFunctionStatement {
 #[derive(Debug, Clone)]
 pub enum Expression {
     Block(BlockExpression),
+    If(IfExpression),
     Binary(BinaryExpression),
     Unary(UnaryExpression),
     Group(GroupExpression),

--- a/src/common/object.rs
+++ b/src/common/object.rs
@@ -5,22 +5,27 @@ use super::{
     position::Position,
 };
 
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct Meta {
+    pub is_return: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Object {
-    Number(f64),
-    String(String),
-    Boolean(bool),
-    Array(Vec<Object>),
-    Nil,
+    Number(f64, Meta),
+    String(String, Meta),
+    Boolean(bool, Meta),
+    Array(Vec<Object>, Meta),
+    Nil(Meta),
 }
 
 impl fmt::Display for Object {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Number(number) => write!(f, "{}", number),
-            Self::String(string) => write!(f, "{}", string.replace("\\n", "\n")),
-            Self::Boolean(boolean) => write!(f, "{}", boolean),
-            Self::Array(array) => {
+            Self::Number(number, ..) => write!(f, "{}", number),
+            Self::String(string, ..) => write!(f, "{}", string.replace("\\n", "\n")),
+            Self::Boolean(boolean, ..) => write!(f, "{}", boolean),
+            Self::Array(array, ..) => {
                 write!(f, "[")?;
                 for object in array {
                     write!(f, "{},", object)?;
@@ -28,25 +33,55 @@ impl fmt::Display for Object {
                 write!(f, "]")?;
                 Ok(())
             }
-            Self::Nil => write!(f, "nil"),
+            Self::Nil(..) => write!(f, "nil"),
         }
     }
 }
 
 impl Object {
+    pub fn meta(&self) -> &Meta {
+        match self {
+            Self::Number(_, meta) => meta,
+            Self::String(_, meta) => meta,
+            Self::Boolean(_, meta) => meta,
+            Self::Array(_, meta) => meta,
+            Self::Nil(meta) => meta,
+        }
+    }
+
+    pub fn set_return(&mut self) {
+        match self {
+            Self::Number(_, meta) => meta.is_return = true,
+            Self::String(_, meta) => meta.is_return = true,
+            Self::Boolean(_, meta) => meta.is_return = true,
+            Self::Array(_, meta) => meta.is_return = true,
+            Self::Nil(meta) => meta.is_return = true,
+        }
+    }
+
+    pub fn is_return(&self) -> bool {
+        match self {
+            Self::Number(_, meta) => meta.is_return,
+            Self::String(_, meta) => meta.is_return,
+            Self::Boolean(_, meta) => meta.is_return,
+            Self::Array(_, meta) => meta.is_return,
+            Self::Nil(meta) => meta.is_return,
+        }
+    }
+
     pub fn is_truthy(&self) -> bool {
         match self {
-            Self::Boolean(boolean) => boolean.clone(),
-            Self::Nil => false,
+            Self::Boolean(boolean, ..) => boolean.clone(),
+            Self::Nil(..) => false,
             _ => true,
         }
     }
 
     pub fn push(&mut self, object: Object, position: Position) -> Result<Object, Error> {
         match self {
-            Object::Array(array) => {
+            Object::Array(array, ..) => {
                 array.push(object);
-                Ok(Object::Array(array.clone()))
+                Ok(Object::Array(array.clone(), Meta::default()))
             }
             _ => Err(Error::new(
                 ErrorType::RuntimeError,
@@ -58,9 +93,9 @@ impl Object {
 
     pub fn pop(&mut self, position: Position) -> Result<Object, Error> {
         match self {
-            Object::Array(array) => {
+            Object::Array(array, ..) => {
                 array.pop();
-                Ok(Object::Array(array.clone()))
+                Ok(Object::Array(array.clone(), Meta::default()))
             }
             _ => Err(Error::new(
                 ErrorType::RuntimeError,

--- a/src/common/token.rs
+++ b/src/common/token.rs
@@ -40,6 +40,7 @@ pub enum TokenType {
     Func,
     If,
     Else,
+    Return,
 
     Read,
     Write,
@@ -88,6 +89,7 @@ impl Display for TokenType {
             Self::Func => write!(f, "func"),
             Self::If => write!(f, "if"),
             Self::Else => write!(f, "else"),
+            Self::Return => write!(f, "return"),
 
             Self::Read => write!(f, "read"),
             Self::Write => write!(f, "write"),

--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::common::{
     error::{Error, ErrorType},
-    object::Object,
+    object::{Meta, Object},
     position::Position,
     token::{Token, TokenType},
 };
@@ -236,9 +236,10 @@ impl Lexer {
             let lexeme: String = self.source[self.start + 1..self.current - 1]
                 .iter()
                 .collect();
-            Ok(Some(
-                self.token(TokenType::String, Some(Object::String(lexeme))),
-            ))
+            Ok(Some(self.token(
+                TokenType::String,
+                Some(Object::String(lexeme, Meta::default())),
+            )))
         } else {
             Err(Error::new(
                 ErrorType::LexingError,
@@ -260,9 +261,10 @@ impl Lexer {
         }
         let lexeme: String = self.source[self.start..self.current].iter().collect();
         if let Ok(float) = lexeme.parse() {
-            Ok(Some(
-                self.token(TokenType::Number, Some(Object::Number(float))),
-            ))
+            Ok(Some(self.token(
+                TokenType::Number,
+                Some(Object::Number(float, Meta::default())),
+            )))
         } else {
             Err(Error::new(
                 ErrorType::LexingError,
@@ -280,11 +282,11 @@ impl Lexer {
         if let Some(ttype) = self.keywords.get(&lexeme) {
             if ttype == &TokenType::Boolean && lexeme == "true" {
                 Ok(Some(
-                    self.token(TokenType::Boolean, Some(Object::Boolean(true))),
+                    self.token(TokenType::Boolean, Some(Object::Boolean(true, Meta::default()))),
                 ))
             } else if ttype == &TokenType::Boolean && lexeme == "false" {
                 Ok(Some(
-                    self.token(TokenType::Boolean, Some(Object::Boolean(false))),
+                    self.token(TokenType::Boolean, Some(Object::Boolean(false, Meta::default()))),
                 ))
             } else {
                 Ok(Some(self.token(ttype.clone(), None)))

--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -37,6 +37,8 @@ impl Lexer {
         self.keywords.insert("func".to_string(), TokenType::Func);
         self.keywords.insert("if".to_string(), TokenType::If);
         self.keywords.insert("else".to_string(), TokenType::Else);
+        self.keywords
+            .insert("return".to_string(), TokenType::Return);
 
         self.keywords.insert("true".to_string(), TokenType::Boolean);
         self.keywords

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -6,7 +6,7 @@ use crate::common::{
         Program, Statement, UnaryExpression,
     },
     error::{Error, ErrorType},
-    object::Object,
+    object::{Meta, Object},
     token::{Token, TokenType},
 };
 
@@ -115,7 +115,7 @@ impl Parser {
                 Expression::Literal(LiteralExpression::new(Token::new(
                     TokenType::Nil,
                     "nil".to_string(),
-                    Some(Object::Nil),
+                    Some(Object::Nil(Meta::default())),
                     self.peek().position,
                 ))),
             ))

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -643,13 +643,7 @@ impl Interpreter {
                 Ok(self.evaluate_identifier_expression(identifier_expression)?)
             }
 
-            Expression::Block(block_expression) => {
-                if let Ok(object) = self.evaluate_block_expression(block_expression) {
-                    Ok(object)
-                } else {
-                    Ok(Object::Nil)
-                }
-            }
+            Expression::Block(block_expression) => self.evaluate_block_expression(block_expression),
 
             Expression::If(if_expression) => self.evaluate_if_expression(if_expression),
 

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -174,8 +174,12 @@ impl Interpreter {
             if let Statement::Return(return_expression) = statement {
                 return_value = self.evaluate_expression(return_expression)?;
                 break;
+            } else if let Statement::Expression(expression) = statement {
+                return_value = self.evaluate_expression(expression)?;
+            } else {
+                return_value = Object::Nil;
+                self.execute_statement(statement)?;
             }
-            self.execute_statement(statement)?;
         }
         self.variables = old_variables;
         Ok(return_value)


### PR DESCRIPTION
## Changes
- Convert the block from statement to expression
- Convert the `if/else` from statement to expression
- Assignment a block to variable
- `return` statement for functions
- `return` statement for blocks
- `return` statement for `if/else` expression
- The last expr will returns in the block
- Add `Meta` to `Object`
- All statement now returns a value, will return `nil` if the statement dose not return anything
- If there a block use return keyword, the main block will return its value directly 
---

### Examples
In blocks and functions
```rust
func foo(num) {
    let num = {
        num + 20 // return to num
    }
    return num - 10 // return to foo
}

write(foo(10), "\n") // 20
```
In `if/else` and functions
```rust
func foo(num) {
    return if num > 0 {
       	num // return to if
    } else if num == 0 {
        0 // return to if
    } else {
        (-num) + 1 // return to if
    } // return to foo
}

write(foo(-11), "\n") // 12
```
Last expr
```rust
func foo(num) {
    // Without return keyword
    if num > 0 {
       	num // return to if
    } else if num == 0 {
        0 // return to if
    } else {
        (-num) + 1 // return to if
    } // return to foo
}
```
Using return in `if/else`.
This will return the value directly
```rust
func foo(num) {
    // This function work with positive numbers only, for example
    if num <= 0 {
        // Return `nil` because the number are not positive
        return nil
    } 
    // This will return the value because its last expr
    num - 1
}
```